### PR TITLE
refactor: remove async module

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@types/arrify": "^1.0.4",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.5.6",
-    "@types/pify": "^3.0.2",
     "codecov": "^3.0.4",
     "eslint": "^5.0.1",
     "eslint-config-prettier": "^3.0.0",
@@ -63,7 +62,7 @@
   },
   "dependencies": {
     "arrify": "^1.0.0",
-    "google-auth-library": "^2.0.0",
-    "pify": "^4.0.1"
+    "chai": "^4.2.0",
+    "google-auth-library": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,11 +42,9 @@
   "license": "MIT",
   "devDependencies": {
     "@types/arrify": "^1.0.4",
-    "@types/async": "^2.0.49",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.5.6",
     "@types/pify": "^3.0.2",
-    "async": "^2.0.0",
     "codecov": "^3.0.4",
     "eslint": "^5.0.1",
     "eslint-config-prettier": "^3.0.0",
@@ -64,6 +62,7 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
+    "@google-cloud/promisify": "^0.3.0",
     "arrify": "^1.0.0",
     "google-auth-library": "^2.0.0",
     "pify": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/arrify": "^1.0.4",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.5.6",
+    "chai": "^4.2.0",
     "codecov": "^3.0.4",
     "eslint": "^5.0.1",
     "eslint-config-prettier": "^3.0.0",
@@ -62,7 +63,6 @@
   },
   "dependencies": {
     "arrify": "^1.0.0",
-    "chai": "^4.2.0",
     "google-auth-library": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "typescript": "~3.2.0"
   },
   "dependencies": {
-    "@google-cloud/promisify": "^0.3.0",
     "arrify": "^1.0.0",
     "google-auth-library": "^2.0.0",
     "pify": "^4.0.1"

--- a/samples/fromProject.js
+++ b/samples/fromProject.js
@@ -16,11 +16,9 @@ if (!projectId) {
 
 // [START gceimages_latest_os_from_project]
 const {GCEImages} = require('gce-images');
-const gceImages = new GCEImages();
-gceImages.getLatest(`${projectId}/my-ubuntu-image`, (err, image) => {
-  if (err) {
-    throw err;
-  }
-  console.log(image);
-});
+async function main() {
+  const gceImages = new GCEImages();
+  console.log(await gceImages.getLatest(`${projectId}/my-ubuntu-image`));
+}
+main().catch(console.error);
 // [END gceimages_latest_os_from_project]

--- a/samples/fromProject.js
+++ b/samples/fromProject.js
@@ -18,7 +18,8 @@ if (!projectId) {
 const {GCEImages} = require('gce-images');
 async function main() {
   const gceImages = new GCEImages();
-  console.log(await gceImages.getLatest(`${projectId}/my-ubuntu-image`));
+  const result = await gceImages.getLatest(`${projectId}/my-ubuntu-image`);
+  console.log(result);
 }
 main().catch(console.error);
 // [END gceimages_latest_os_from_project]

--- a/samples/latestSpecificOS.js
+++ b/samples/latestSpecificOS.js
@@ -9,11 +9,9 @@
 
 // [START gceimages_latest_os_specific_version]
 const {GCEImages} = require('gce-images');
-const gceImages = new GCEImages();
-gceImages.getLatest('ubuntu-1404', (err, image) => {
-  if (err) {
-    throw err;
-  }
-  console.log(image);
-});
+async function main() {
+  const gceImages = new GCEImages();
+  console.log(await gceImages.getLatest('ubuntu-1404'));
+}
+main().catch(console.error);
 // [START gceimages_latest_os_specific_version]

--- a/samples/latestSpecificOS.js
+++ b/samples/latestSpecificOS.js
@@ -11,7 +11,8 @@
 const {GCEImages} = require('gce-images');
 async function main() {
   const gceImages = new GCEImages();
-  console.log(await gceImages.getLatest('ubuntu-1404'));
+  const result = await gceImages.getLatest('ubuntu-1404');
+  console.log(result);
 }
 main().catch(console.error);
 // [START gceimages_latest_os_specific_version]

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -9,11 +9,9 @@
 
 // [START gceimages_quickstart]
 const {GCEImages} = require('gce-images');
-const gceImages = new GCEImages();
-gceImages.getAll((err, images) => {
-  if (err) {
-    throw err;
-  }
-  console.log(images);
-});
+async function main() {
+  const gceImages = new GCEImages();
+  console.log(await gceImages.getAll());
+}
+main().catch(console.error);
 // [END gceimages_quickstart]

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -11,7 +11,8 @@
 const {GCEImages} = require('gce-images');
 async function main() {
   const gceImages = new GCEImages();
-  console.log(await gceImages.getAll());
+  const result = await gceImages.getLatest('ubuntu-1404');
+  console.log(result);
 }
 main().catch(console.error);
 // [END gceimages_quickstart]

--- a/samples/specificOS.js
+++ b/samples/specificOS.js
@@ -9,11 +9,9 @@
 
 // [START gceimages_latest_os]
 const {GCEImages} = require('gce-images');
-const gceImages = new GCEImages();
-gceImages.getLatest('ubuntu', (err, image) => {
-  if (err) {
-    throw err;
-  }
-  console.log(image);
-});
+async function main() {
+  const gceImages = new GCEImages();
+  console.log(await gceImages.getLatest('ubuntu'));
+}
+main().catch(console.error);
 // [END gceimages_latest_os]

--- a/samples/specificOS.js
+++ b/samples/specificOS.js
@@ -11,7 +11,8 @@
 const {GCEImages} = require('gce-images');
 async function main() {
   const gceImages = new GCEImages();
-  console.log(await gceImages.getLatest('ubuntu'));
+  const result = await gceImages.getLatest('ubuntu');
+  console.log(result);
 }
 main().catch(console.error);
 // [END gceimages_latest_os]

--- a/samples/system-test/samples.js
+++ b/samples/system-test/samples.js
@@ -27,7 +27,7 @@ describe('quickstart', () => {
 });
 
 describe('from project', () => {
-  it('should return a an image', async () => {
+  it('should return an image', async () => {
     const {stdout} = await execa('node', ['fromProject.js']);
     assert.match(stdout, /^{/);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@
 import * as arrify from 'arrify';
 import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 import * as pify from 'pify';
+const {promisifyAll} = require('@google-cloud/promisify');
 
 export interface GCEImagesConfig extends GoogleAuthOptions {
   authClient?: GoogleAuth;
@@ -122,8 +123,10 @@ export class GCEImages {
    * @param {function} callback - Callback function.
    */
   getAll(cb: GetAllCallback): void;
+  getAll(opts: GetOptions|string): Promise<Image[][]|ImagesMap[]>;
   getAll(opts: GetOptions|string, cb: GetAllCallback): void;
-  getAll(opts: GetOptions|string|GetAllCallback, cb?: GetAllCallback): void {
+  getAll(opts: GetOptions|string|GetAllCallback, cb?: GetAllCallback):
+      void|Promise<Image[][]|ImagesMap[]> {
     const {options, callback} =
         this._parseArguments<GetOptions, GetAllCallback>(opts, cb);
     const osNamesToImages = new Map<string, Image[]>();
@@ -312,3 +315,5 @@ export class GCEImages {
         imageA.creationTimestamp > imageB.creationTimestamp ? -1 : 0;
   }
 }
+
+promisifyAll(GCEImages);

--- a/system-test/test.ts
+++ b/system-test/test.ts
@@ -5,7 +5,7 @@
  * See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
  */
 
-import * as assert from 'assert';
+const {assert} = require('chai');
 import {GCEImages, Image, ImageMap, ImagesMap} from '../src';
 
 const gceImages = new GCEImages();
@@ -29,17 +29,17 @@ describe('system tests', () => {
   });
 
   describe('all', () => {
-    it('should default to deprecated: false', done => {
-      gceImages.getAll((err, is) => {
-        const images = is as ImagesMap;
-        assert.ifError(err);
+    it('should default to deprecated: false', async () => {
+      try {
+        const images = await gceImages.getAll() as ImagesMap;
         assert.strictEqual(typeof images, 'object');
         Object.keys(images).forEach((osName) => {
           assert.strictEqual(
               images[osName].length, allImagesByOsName.stable[osName].length);
         });
-        done();
-      });
+      } catch (err) {
+        assert.ifError(err);
+      }
     });
 
     it('should get all of the images available for a specific OS', (done) => {
@@ -50,34 +50,33 @@ describe('system tests', () => {
         assert(Array.isArray(images));
         assert.strictEqual(
             images!.length, allImagesByOsName.stable[osName].length);
-
         done();
       });
     });
   });
 
   describe('latest', () => {
-    it('should get only the latest image from every OS', (done) => {
-      gceImages.getLatest((err, is) => {
-        const images = is as ImageMap;
-        assert.ifError(err);
+    it('should get only the latest image from every OS', async () => {
+      try {
+        const images = await gceImages.getLatest() as ImageMap;
         assert.strictEqual(typeof images, 'object');
         Object.keys(images).forEach((osName) => {
           assert.strictEqual(typeof images[osName], 'object');
         });
-        done();
-      });
+      } catch (err) {
+        assert.ifError(err);
+      }
     });
 
-    it('should get the latest image for a specific OS', (done) => {
+    it('should get the latest image for a specific OS', async () => {
       const osName = 'ubuntu';
-
-      gceImages.getLatest(osName, (err, image) => {
-        assert.ifError(err);
+      try {
+        const image = await gceImages.getLatest(osName) as Image;
         assert.strictEqual(typeof image, 'object');
-        assert((image as Image).selfLink.indexOf(osName) > -1);
-        done();
-      });
+        assert(image.selfLink.indexOf(osName) > -1);
+      } catch (err) {
+        assert.ifError(err);
+      }
     });
 
     it('should get the latest image for a specific OS version', (done) => {

--- a/system-test/test.ts
+++ b/system-test/test.ts
@@ -6,7 +6,6 @@
  */
 
 import * as assert from 'assert';
-import * as async from 'async';
 import {GCEImages, Image, ImageMap, ImagesMap} from '../src';
 
 const gceImages = new GCEImages();
@@ -21,24 +20,12 @@ describe('system tests', () => {
     stable: {},
   };
 
-  before(done => {
-    // Get counts.
-    async.forEachOf(
-        allImagesByOsName,
-
-        (_, key, next) => {
-          gceImages.getAll(
-              {deprecated: key === 'deprecated'}, (err, images) => {
-                if (err) {
-                  next(err);
-                  return;
-                }
-                allImagesByOsName[key] = images as ImagesMap;
-                next();
-              });
-        },
-
-        done);
+  before(async () => {
+    [[allImagesByOsName.deprecated], [allImagesByOsName.stable]] =
+        await Promise.all(
+            Object.keys(allImagesByOsName).map(key => gceImages.getAll({
+              deprecated: key === 'deprecated'
+            }) as Promise<ImagesMap[]>));
   });
 
   describe('all', () => {

--- a/system-test/test.ts
+++ b/system-test/test.ts
@@ -30,16 +30,12 @@ describe('system tests', () => {
 
   describe('all', () => {
     it('should default to deprecated: false', async () => {
-      try {
-        const images = await gceImages.getAll() as ImagesMap;
-        assert.strictEqual(typeof images, 'object');
-        Object.keys(images).forEach((osName) => {
-          assert.strictEqual(
-              images[osName].length, allImagesByOsName.stable[osName].length);
-        });
-      } catch (err) {
-        assert.ifError(err);
-      }
+      const images = await gceImages.getAll() as ImagesMap;
+      assert.strictEqual(typeof images, 'object');
+      Object.keys(images).forEach((osName) => {
+        assert.strictEqual(
+            images[osName].length, allImagesByOsName.stable[osName].length);
+      });
     });
 
     it('should get all of the images available for a specific OS', (done) => {
@@ -57,26 +53,18 @@ describe('system tests', () => {
 
   describe('latest', () => {
     it('should get only the latest image from every OS', async () => {
-      try {
-        const images = await gceImages.getLatest() as ImageMap;
-        assert.strictEqual(typeof images, 'object');
-        Object.keys(images).forEach((osName) => {
-          assert.strictEqual(typeof images[osName], 'object');
-        });
-      } catch (err) {
-        assert.ifError(err);
-      }
+      const images = await gceImages.getLatest() as ImageMap;
+      assert.strictEqual(typeof images, 'object');
+      Object.keys(images).forEach((osName) => {
+        assert.strictEqual(typeof images[osName], 'object');
+      });
     });
 
     it('should get the latest image for a specific OS', async () => {
       const osName = 'ubuntu';
-      try {
-        const image = await gceImages.getLatest(osName) as Image;
-        assert.strictEqual(typeof image, 'object');
-        assert(image.selfLink.indexOf(osName) > -1);
-      } catch (err) {
-        assert.ifError(err);
-      }
+      const image = await gceImages.getLatest(osName) as Image;
+      assert.strictEqual(typeof image, 'object');
+      assert(image.selfLink.indexOf(osName) > -1);
     });
 
     it('should get the latest image for a specific OS version', (done) => {

--- a/system-test/test.ts
+++ b/system-test/test.ts
@@ -21,11 +21,11 @@ describe('system tests', () => {
   };
 
   before(async () => {
-    [[allImagesByOsName.deprecated], [allImagesByOsName.stable]] =
+    [allImagesByOsName.deprecated, allImagesByOsName.stable] =
         await Promise.all(
             Object.keys(allImagesByOsName).map(key => gceImages.getAll({
               deprecated: key === 'deprecated'
-            }) as Promise<ImagesMap[]>));
+            }) as Promise<ImagesMap>));
   });
 
   describe('all', () => {


### PR DESCRIPTION
Towards googleapis/google-cloud-node/issues/2883

- [x] Tests and linter pass

* Eliminates usage of `async` and `pify` modules.
* Uses `chai` for `assert`s.
* As per googleapis/google-cloud-node/issues/2887 discussion refactores library methods to support promises as `async` first with callbackification support rather than using `promisifyAll`.
* Updates samples to promote async/await usage.
* Update main system tests to test async/await and callback use of API methods.


